### PR TITLE
Add `passNode` option to pass `props.node`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function rehypeReact(options) {
   var createElement = settings.createElement
   var Fragment = settings.Fragment
   var components = settings.components || {}
+  var passNode = settings.passNode
 
   this.Compiler = compiler
 
@@ -38,7 +39,14 @@ function rehypeReact(options) {
 
   // Wrap `createElement` to pass components in.
   function h(name, props, children) {
-    var component = has.call(components, name) ? components[name] : name
+    var component = name
+    if (has.call(components, name)) {
+      component = components[name]
+      if (passNode) {
+        props.node = this
+      }
+    }
+
     return createElement(component, props, children)
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ React key prefix (`string`, default: `'h-'`).
 
 ###### `options.passNode`
 
-Expose HAST Node objects to `node` prop of react components
+Pass the original hast node as `props.node` to custom React components
 (`boolean`, default: `false`).
 
 ## Security

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,11 @@ instead of `<p>`, so something like this:
 
 React key prefix (`string`, default: `'h-'`).
 
+###### `options.passNode`
+
+Expose HAST Node objects to `node` prop of react components
+(`boolean`, default: `false`).
+
 ## Security
 
 Use of `rehype-react` can open you up to a [cross-site scripting (XSS)][xss]

--- a/test.js
+++ b/test.js
@@ -141,5 +141,26 @@ test('React ' + React.version, function (t) {
     'should transform an element with align property'
   )
 
+  const headingNode = h('h1')
+  const Heading1 = function (props) {
+    return React.createElement('h1', props)
+  }
+  t.deepEqual(
+    unified()
+      .use(rehype2react, {
+        createElement: React.createElement,
+        passNode: true,
+        components: {
+          h1: Heading1
+        }
+      })
+      .stringify(u('root', [headingNode, h('p')])),
+    React.createElement('div', {}, [
+      React.createElement(Heading1, {key: 'h-2', node: headingNode}, undefined),
+      React.createElement('p', {key: 'h-3'}, undefined)
+    ]),
+    'should expose node from node prop'
+  )
+
   t.end()
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,11 +2,17 @@
 
 import {Transformer} from 'unified'
 import {Prefix, CreateElementLike} from 'hast-to-hyperscript'
+import {Node} from 'unist'
 
 declare namespace rehypeReact {
   type FragmentLike<T> = (props: any) => T | null
 
-  type ComponentLike<T> = (props: {[prop: string]: unknown}) => T | null
+  type ComponentProps = {
+    node?: Node
+    [prop: string]: unknown
+  }
+
+  type ComponentLike<T> = (props: ComponentProps) => T | null
 
   interface Options<H extends CreateElementLike> {
     /**
@@ -34,6 +40,13 @@ declare namespace rehypeReact {
      * @defaultValue 'h-'
      */
     prefix?: Prefix
+
+    /**
+     * Expose HAST Node objects to `node` prop of react components
+     *
+     * @defaultValue false
+     */
+    passNode?: boolean
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,9 +7,9 @@ import {Node} from 'unist'
 declare namespace rehypeReact {
   type FragmentLike<T> = (props: any) => T | null
 
-  type ComponentProps = {
-    node?: Node
+  interface ComponentProps {
     [prop: string]: unknown
+    node?: Node
   }
 
   type ComponentLike<T> = (props: ComponentProps) => T | null

--- a/types/rehype-react-test.tsx
+++ b/types/rehype-react-test.tsx
@@ -43,6 +43,19 @@ unified().use(rehypeToReact, {
   }
 })
 
+unified().use(rehypeToReact, {
+  createElement: React.createElement,
+  passNode: true
+})
+
+unified().use(rehypeToReact, {
+  createElement: React.createElement,
+  passNode: true,
+  components: {
+    a: (props: rehypeToReact.ComponentProps) => <a>{props.node}</a>
+  }
+})
+
 // Mismatch between framework of createElement and components or Fragment should fail
 unified().use(rehypeToReact, {
   createElement: virtualDomCreateElement,


### PR DESCRIPTION
Fixes #19

And I added a type alias, `ComponentProps` because I found that type inference for component's props argument doesn't work. So adopters who want to access props, they have to set `ComponentProps` manually.

```ts
unified().use(rehypeToReact, {
  createElement: React.createElement,
  passNode: true,
  components: {
    a: (props) => <a>{props.node}</a> // This will throws an error because `props` is considered as `any` implicitly.
  }
})
```

So I need to fix like

```ts
unified().use(rehypeToReact, {
  createElement: React.createElement,
  passNode: true,
  components: {
    a: (props: { node? unist.Node}) => <a>{props.node}</a>
    // Or like this with `ComponentProps`
    // a: (props: rehypeToReact.ComponentProps) => <a>{props.node}</a>
  }
})
```