### PR TITLE
Fix declaration in `.d.ts` file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,6 @@ import type {Options} from './lib/index.js'
  *   Configuration.
  */
 // Note: defining all react nodes as result value seems to trip TS up.
-const rehypeReact: Plugin<[Options], Root, ReactElement<unknown>>
+declare const rehypeReact: Plugin<[Options], Root, ReactElement<unknown>>
 export default rehypeReact
 export type {Options}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

resolves

```ts
node_modules/rehype-react/index.d.ts:13:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

13 const rehypeReact: Plugin<[Options], Root, ReactElement<unknown>>
   ~~~~~
```

<!--do not edit: pr-->
