### PR TITLE
Fix to correctly compile intrinsic types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 coverage/
 node_modules/
 .DS_Store
-lib/index.d.ts
+lib/*.d.ts
 test.d.ts
 *.log
 yarn.lock

--- a/lib/complex-types.ts
+++ b/lib/complex-types.ts
@@ -1,7 +1,7 @@
 import type {ComponentType} from 'react'
 import type {Element} from 'hast'
 
-export interface WithNode {
+interface WithNode {
   node: Element
 }
 

--- a/lib/complex-types.ts
+++ b/lib/complex-types.ts
@@ -17,7 +17,7 @@ export interface ComponentsWithNodeOptions {
   components?: Partial<
     {
       [TagName in keyof JSX.IntrinsicElements]:
-        | string
+        | keyof JSX.IntrinsicElements
         | ComponentType<WithNode & JSX.IntrinsicElements[TagName]>
     }
   >
@@ -36,7 +36,7 @@ export interface ComponentsWithoutNodeOptions {
   components?: Partial<
     {
       [TagName in keyof JSX.IntrinsicElements]:
-        | string
+        | keyof JSX.IntrinsicElements
         | ComponentType<JSX.IntrinsicElements[TagName]>
     }
   >

--- a/lib/custom-types.ts
+++ b/lib/custom-types.ts
@@ -1,0 +1,43 @@
+import type {ComponentType} from 'react'
+import type {Element} from 'hast'
+
+export interface WithNode {
+  node: Element
+}
+
+export interface ComponentsWithNodeOptions {
+  /**
+   * Expose hast elements as a `node` field in components
+   */
+  passNode: true
+  /**
+   * Override default elements (such as `<a>`, `<p>`, etcetera) by passing an
+   * object mapping tag names to components.
+   */
+  components?: Partial<
+    {
+      [TagName in keyof JSX.IntrinsicElements]:
+        | string
+        | ComponentType<WithNode & JSX.IntrinsicElements[TagName]>
+    }
+  >
+}
+
+export interface ComponentsWithoutNodeOptions {
+  /**
+   * Expose hast elements as a `node` field in components.
+   */
+  passNode?: false | undefined
+
+  /**
+   * Override default elements (such as `<a>`, `<p>`, etcetera) by passing an
+   * object mapping tag names to components.
+   */
+  components?: Partial<
+    {
+      [TagName in keyof JSX.IntrinsicElements]:
+        | string
+        | ComponentType<JSX.IntrinsicElements[TagName]>
+    }
+  >
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@
  * @property {string|undefined} [prefix='h-']
  *   React key prefix
  *
- * @typedef {SharedOptions & (import("./custom-types").ComponentsWithNodeOptions|import("./custom-types").ComponentsWithoutNodeOptions)} Options
+ * @typedef {SharedOptions & (import("./complex-types").ComponentsWithNodeOptions|import("./complex-types").ComponentsWithoutNodeOptions)} Options
  */
 
 import {toH} from 'hast-to-hyperscript'

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,25 +20,7 @@
  * @property {string|undefined} [prefix='h-']
  *   React key prefix
  *
- * @typedef WithNode
- * @property {Element} node
- *   Current hast element.
- *
- * @typedef ComponentsWithNodeOptions
- * @property {true} passNode
- *   Expose hast elements as a `node` field in components.
- * @property {Partial<{[TagName in keyof JSX.IntrinsicElements]: string|((props: WithNode & JSX.IntrinsicElements[TagName]) => ReactNode)}>} [components]
- *   Override default elements (such as `<a>`, `<p>`, etcetera) by passing an
- *   object mapping tag names to components.
- *
- * @typedef ComponentsWithoutNodeOptions
- * @property {false|undefined} [passNode]
- *   Expose hast elements as a `node` field in components.
- * @property {Partial<{[TagName in keyof JSX.IntrinsicElements]: string|((props: JSX.IntrinsicElements[TagName]) => ReactNode)}>} [components]
- *   Override default elements (such as `<a>`, `<p>`, etcetera) by passing an
- *   object mapping tag names to components.
- *
- * @typedef {SharedOptions & (ComponentsWithNodeOptions|ComponentsWithoutNodeOptions)} Options
+ * @typedef {SharedOptions & (import("./custom-types").ComponentsWithNodeOptions|import("./custom-types").ComponentsWithoutNodeOptions)} Options
  */
 
 import {toH} from 'hast-to-hyperscript'


### PR DESCRIPTION
leverage ComponentType to allow for class components as well.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Avoid inlining intrinsic type.
Use `ComponentType` to allow for class components.

similar to https://github.com/remarkjs/react-markdown/pull/638

<!--do not edit: pr-->
