### PR TITLE
Fix to improve removal of whitespace between tables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,9 @@ export default function rehypeReact(options) {
     // See: <https://github.com/facebook/react/pull/7515>.
     // See: <https://github.com/remarkjs/remark-react/issues/64>.
     if (children && tableElements.has(name)) {
-      children = children.filter((child) => child !== '\n')
+      children = children.filter(
+        (child) => typeof child !== 'string' || child.trim().length > 0
+      )
     }
 
     if (options.components && own.call(options.components, name)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@
 import {toH} from 'hast-to-hyperscript'
 // @ts-expect-error: hush.
 import tableCellStyle from '@mapbox/hast-util-table-cell-style'
+import {whitespace} from 'hast-util-whitespace'
 
 const own = {}.hasOwnProperty
 const tableElements = new Set([
@@ -90,9 +91,7 @@ export default function rehypeReact(options) {
     // See: <https://github.com/facebook/react/pull/7515>.
     // See: <https://github.com/remarkjs/remark-react/issues/64>.
     if (children && tableElements.has(name)) {
-      children = children.filter(
-        (child) => typeof child !== 'string' || child.trim().length > 0
-      )
+      children = children.filter((child) => !whitespace(child))
     }
 
     if (options.components && own.call(options.components, name)) {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/hast": "^2.0.0",
     "@types/react": "^17.0.0",
     "hast-to-hyperscript": "^10.0.0",
+    "hast-util-whitespace": "^2.0.0",
     "unified": "^10.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -168,6 +168,22 @@ test('React ' + React.version, (t) => {
     'should transform an element with align property'
   )
 
+  t.deepEqual(
+    processor.stringify(
+      u('root', [
+        h('table', {}, ['\n  ', h('tbody', {}, ['\n  ', h('tr', {})])])
+      ])
+    ),
+    React.createElement('div', {}, [
+      React.createElement('table', {key: 'h-1'}, [
+        React.createElement('tbody', {key: 'h-2'}, [
+          React.createElement('tr', {key: 'h-3'}, undefined)
+        ])
+      ])
+    ]),
+    'should transform a table with whitespace'
+  )
+
   const headingNode = h('h1')
   /** @param {object} props */
   const Heading1 = function (props) {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

#29 added a fix to remove whitespace nodes from tables, since they caused a warning in React (#28). Though the check for strings containing just a newline is too specific, because whitespace nodes can consist of arbitrary combinations of newlines, tabs and spaces. 

When using `rehype-parse` and `rehype-react` to transform html documents containing tables that have indentation, react still gives a warning for whitespace within a table, because the check fails here.

I used a more robust check to filter out nodes containing only whitespace that will work for any combination of whitespace characters.

I also added a test to check for whitespace removal on tables.

<!--do not edit: pr-->
