### PR TITLE
Fix to not strip whitespace in `th`, `td`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,6 @@ const tableElements = new Set([
   'tbody',
   'tfoot',
   'tr',
-  'th',
-  'td'
 ])
 
 /**

--- a/test.js
+++ b/test.js
@@ -171,13 +171,16 @@ test('React ' + React.version, (t) => {
   t.deepEqual(
     processor.stringify(
       u('root', [
-        h('table', {}, ['\n  ', h('tbody', {}, ['\n  ', h('tr', {})])])
+        h('table', {}, ['\n  ', h('tbody', {}, ['\n  ', h('tr', {}, ['\n  ', h('th', {}, ['\n  ']), h('td', {}, ['\n  '])])])])
       ])
     ),
     React.createElement('div', {}, [
       React.createElement('table', {key: 'h-1'}, [
         React.createElement('tbody', {key: 'h-2'}, [
-          React.createElement('tr', {key: 'h-3'}, undefined)
+          React.createElement('tr', {key: 'h-3'}, [
+            React.createElement('th', {key: 'h-4'}, ['\n  ']),
+            React.createElement('td', {key: 'h-5'}, ['\n  ']),
+          ])
         ])
       ])
     ]),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Since #29 rehype-react removes any whitespaces in table elements but `th` and `td` should not be its target when filtering because whitespaces are valid to appear inside them and of course React does not warn about them. This PR removes `th` and `td` from the list of target table elements and adds tests to verify they remain the same. Thanks.

<!--do not edit: pr-->
