### PR TITLE
Feat: `fixTableCellAlign` option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@
  *   into inline styles.
  *   Keep it on when working with markdown, turn it off when working
  *   with markup for emails.
- *   Default: true.
+ *   The default is `true`.
  *
  * @typedef {SharedOptions & (import('./complex-types').ComponentsWithNodeOptions|import('./complex-types').ComponentsWithoutNodeOptions)} Options
  *   Configuration.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,12 @@
  *   You should typically pass `React.Fragment`.
  * @property {string|undefined} [prefix='h-']
  *   React key prefix.
+ * @property {boolean|undefined} [fixTableCellAlign=true]
+ *   Fix obsolete align attributes on table cells by turning them
+ *   into inline styles.
+ *   Keep it on when working with markdown, turn it off when working
+ *   with markup for emails.
+ *   Default: true.
  *
  * @typedef {SharedOptions & (import('./complex-types').ComponentsWithNodeOptions|import('./complex-types').ComponentsWithoutNodeOptions)} Options
  *   Configuration.
@@ -51,13 +57,19 @@ export default function rehypeReact(options) {
 
   const createElement = options.createElement
 
+  const fixTableCellAlign = options.fixTableCellAlign !== false
+
   Object.assign(this, {Compiler: compiler})
 
   /** @type {import('unified').CompilerFunction<Root, ReactNode>} */
   function compiler(node) {
     /** @type {ReactNode} */
-    // @ts-expect-error: assume `name` is a known element.
-    let result = toH(h, tableCellStyle(node), options.prefix)
+    let result = toH(
+      // @ts-expect-error: assume `name` is a known element.
+      h,
+      fixTableCellAlign ? tableCellStyle(node) : node,
+      options.prefix
+    )
 
     if (node.type === 'root') {
       // Invert <https://github.com/syntax-tree/hast-to-hyperscript/blob/d227372/index.js#L46-L56>.

--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,13 @@ React key prefix (`string`, default: `'h-'`).
 Pass the original hast node as `props.node` to custom React components
 (`boolean`, default: `false`).
 
+###### `options.fixTableCellAlign`
+
+Fix obsolete align attributes on table cells by turning them
+into inline styles.
+Keep it on when working with markdown, turn it off when working
+with markup for emails (`boolean`, default: `true`).
+
 ## Types
 
 This package is fully typed with [TypeScript][].

--- a/readme.md
+++ b/readme.md
@@ -177,9 +177,9 @@ Pass the original hast node as `props.node` to custom React components
 ###### `options.fixTableCellAlign`
 
 Fix obsolete align attributes on table cells by turning them
-into inline styles.
+into inline styles (`boolean`, default: `true`).
 Keep it on when working with markdown, turn it off when working
-with markup for emails (`boolean`, default: `true`).
+with markup for emails.
 
 ## Types
 

--- a/test.js
+++ b/test.js
@@ -215,5 +215,38 @@ test('React ' + React.version, (t) => {
     'should expose node from node prop'
   )
 
+  t.deepEqual(
+    unified()
+      .use(rehypeReact, {
+        createElement: React.createElement,
+        fixTableCellAlign: false
+      })
+      .stringify(
+        u('root', [
+          h('table', {align: 'top'}, [
+            '\n  ',
+            h('tbody', {}, [
+              '\n  ',
+              h('tr', {}, [
+                h('th', {}, ['\n  ']),
+                h('td', {align: 'center'}, ['\n  '])
+              ])
+            ])
+          ])
+        ])
+      ),
+    React.createElement('div', {}, [
+      React.createElement('table', {key: 'h-1', align: 'top'}, [
+        React.createElement('tbody', {key: 'h-2'}, [
+          React.createElement('tr', {key: 'h-3'}, [
+            React.createElement('th', {key: 'h-4'}, ['\n  ']),
+            React.createElement('td', {key: 'h-5', align: 'center'}, ['\n  '])
+          ])
+        ])
+      ])
+    ]),
+    'should respect mapDepricatedTableCellAttrsToInlineCss option'
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Adds a new plugin option, ~~`mapDepricatedTableCellAttrsToInlineCss`~~`fixTableCellAlign`, which controls whether table-related attributes are mapped to inline CSS styles. Defaults to `true`.

Closes #47

_Notes:_ 
1. I created this using Github's online vscode editor (i.e. press `.` when viewing a repo) so I'm not sure if this conforms to any required lint/formatting rules.
2. My own preference is to default to clear, verbose names, but I won't be offended if you'd prefer to rename this option to something else.

<!--do not edit: pr-->